### PR TITLE
Add commander options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,56 @@
 
 Create a markdown blog file using the CLI
 
-# TODO
+## Install
 
-- Pass options in command invocation so we don't have to be prompted every time
-- Add option to only create a file instead of a directory
-- Add option to create MDX file
+To use once:
+
+```
+npx create-md-blog
+```
+
+To use as a dev dependency on a particular project:
+
+```
+npm install --save-dev create-md-blog
+npm md-blog
+```
+
+Install globally:
+
+```
+npm install --global create-md-blog
+md-blog
+```
+
+## Command Line Options
+
+```
+Usage: md-blog [options]
+
+Options:
+  -s, --standalone             Create a standalone file instead of a blog
+                               directory
+  --no-standalone
+  --mdx                        Create MDX file (default: false)
+  -a, --author <author entry>  Author of the blog post
+  -t, --title <title>          Title of the blog
+  --slug <slug>                Slug path of the blog file
+  --tags <tags...>             Specify tags
+  -p, --prompt-new-tags        Prompt to add new tags (default: false)
+  -d, --date <blog date>       Date posted for the blog
+  -h, --help                   display help for command
+```
+
+Any unspecified options will be prompted:
+
+```
+✔ Create a standalone file?
+(Yes if you're not including other files like images) › no
+✔ Who is creating this blog? › charles
+✔ Title of the blog … Example blog
+✔ URL slug for the blog … example-blog
+✔ Pick existing tags › nice
+✔ Date of blog › May 23 2022
+Created blog directory blog/2022-05-23-example-blog and index.md file
+```

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
+    "commander": "^9.2.0",
     "front-matter": "^4.0.2",
     "js-yaml": "^4.1.0",
     "prompts": "^2.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,7 @@ specifiers:
   '@types/js-yaml': ^4.0.5
   '@types/node': ^17.0.35
   '@types/prompts': ^2.0.14
+  commander: ^9.2.0
   front-matter: ^4.0.2
   js-yaml: ^4.1.0
   nodemon: ^2.0.16
@@ -12,6 +13,7 @@ specifiers:
   typescript: ^4.6.4
 
 dependencies:
+  commander: 9.2.0
   front-matter: 4.0.2
   js-yaml: 4.1.0
   prompts: 2.4.2
@@ -207,6 +209,11 @@ packages:
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: true
+
+  /commander/9.2.0:
+    resolution: {integrity: sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==}
+    engines: {node: ^12.20.0 || >=14}
+    dev: false
 
   /concat-map/0.0.1:
     resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}

--- a/src/bin/md-blog.ts
+++ b/src/bin/md-blog.ts
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 
-import { resolve } from 'path';
-import { getAuthors } from '../lib/authors';
-import { getSlugsAndTags } from '../lib/blogData';
-import { createBlogFile } from '../lib/index';
-import { promptQuestions } from '../lib/questions';
+import { Option, program } from 'commander';
+import { join, resolve } from 'path';
+import { CLIPromptOptions, createBlogFile, getAuthors, getSlugsAndTags, promptQuestions } from '../lib';
 
 const BLOG_DIR = './blog';
 const AUTHORS_FILE = 'authors.yml';
@@ -13,22 +11,49 @@ const pad = (d: { toString: () => string }) => d.toString().padStart(2, '0');
 const fmtDate = (date: Date) => [date.getFullYear(), date.getMonth() + 1, date.getDate()].map((d) => pad(d)).join('-');
 
 export async function main() {
+  const authorChoices = await getAuthors(resolve(BLOG_DIR, AUTHORS_FILE));
+  const fileData = await getSlugsAndTags(BLOG_DIR);
+
+  program
+    .option('-s, --standalone', 'Create a standalone file instead of a blog directory')
+    .option('--no-standalone')
+    .option('--mdx', 'Create MDX file', false)
+    .addOption(
+      new Option('-a, --author <author entry>', 'Author of the blog post').choices(authorChoices.map(([name]) => name))
+    )
+    .option('-t, --title <title>', 'Title of the blog')
+    .option('--slug <slug>', 'Slug path of the blog file')
+    .addOption(new Option('--tags <tags...>', 'Specify tags').choices(Array.from(fileData.tags)))
+    .option('-p, --prompt-new-tags', 'Prompt to add new tags', false)
+    // This is horrible
+    .option('-d, --date <blog date>', 'Date posted for the blog', function (date) {
+      if (date === 'now' || date === 'today') return new Date();
+      return new Date(date);
+    });
+
+  program.parse();
+
+  const options: CLIPromptOptions = program.opts();
+
   try {
-    const authorChoices = await getAuthors(resolve(BLOG_DIR, AUTHORS_FILE));
-    const fileData = await getSlugsAndTags(BLOG_DIR);
-    const response = await promptQuestions(authorChoices, fileData);
-    const { title, author, date, slug, tags: existingTags, newTags } = response;
-    const tags = Array.from(
-      new Set<string>(
-        existingTags
-          .concat(newTags)
-          .filter((t: string) => !!t)
-          .map((t: string) => t.toLowerCase())
-      )
-    );
-    await createBlogFile({ title, author, path: `${BLOG_DIR}/${fmtDate(date)}-${slug}`, tags });
+    const response = await promptQuestions(authorChoices, fileData, options);
+    const { title, author, date, slug, tags, standalone } = response;
+    const path = join(BLOG_DIR, `${fmtDate(date)}-${slug}`);
+    const file = await createBlogFile({
+      title,
+      author,
+      path,
+      tags,
+      standalone,
+      mdx: options.mdx,
+    });
+    if (standalone) {
+      process.stdout.write(`Created blog file ${file}\n`);
+    } else {
+      process.stdout.write(`Created blog directory ${path} and index.${options.mdx ? 'mdx' : 'md'} file\n`);
+    }
   } catch (e) {
-    console.error(e);
+    process.stderr.write(`${(e as Error).stack as string}\n`);
   }
 }
 

--- a/src/lib/authors.ts
+++ b/src/lib/authors.ts
@@ -1,14 +1,6 @@
 import { readFile } from 'fs/promises';
 import { load } from 'js-yaml';
-
-export interface Author {
-  name: string;
-  title: string;
-  url: string;
-  image_url: string;
-}
-
-export type AuthorChoices = [string, Author][];
+import { AuthorChoices } from './types';
 
 export async function getAuthors(filePath: string): Promise<AuthorChoices> {
   try {

--- a/src/lib/blogData.ts
+++ b/src/lib/blogData.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import fm from 'front-matter';
 import { readFile } from 'fs/promises';
 import readdirp from 'readdirp';

--- a/src/lib/blogData.ts
+++ b/src/lib/blogData.ts
@@ -1,10 +1,7 @@
 import fm from 'front-matter';
 import { readFile } from 'fs/promises';
 import readdirp from 'readdirp';
-
-export type BlogData = { slugs: Set<string>; tags: Set<string> };
-
-type BlogAttributes = { slug: string; tags: string | string[] };
+import { BlogAttributes, BlogData } from './types';
 
 function getFileSlug(fileName: string) {
   const fileSlug = fileName.match(/.*\d{4}-\d{2}-\d{2}-(.*?)(\/index)?.mdx?/);
@@ -24,10 +21,10 @@ function getAllMarkdownFiles(dir: string): Promise<string[]> {
         allFilePaths.push(entry.fullPath);
       })
       .on('warn', function (warn) {
-        process.stderr.write('readdirp Warn: ' + warn);
+        process.stderr.write('readdirp Warn: ' + warn + '\n');
       })
       .on('error', function (err) {
-        process.stderr.write('readdirp Error: ' + err.stack);
+        process.stderr.write('readdirp Error: ' + err.stack + '\n');
       })
       .on('end', function () {
         resolve(allFilePaths);

--- a/src/lib/blogFile.ts
+++ b/src/lib/blogFile.ts
@@ -1,0 +1,22 @@
+import { mkdir, writeFile } from 'fs/promises';
+import yaml from 'js-yaml';
+import { CreateBlogOptions } from './types';
+
+async function createBlogDir(blogDir: string) {
+  await mkdir(blogDir, { recursive: true });
+  return blogDir;
+}
+
+export async function createBlogFile(opts: CreateBlogOptions) {
+  const { title, author: authors, tags, path, standalone = false, mdx = false } = opts;
+
+  const frontMatter = `---\n${yaml.dump({ title, authors, tags }, { flowLevel: 1 })}---\n\n<!--truncate-->\n`;
+
+  const ext = mdx ? '.mdx' : '.md';
+  const filePath = standalone ? path + ext : path + '/index' + ext;
+
+  if (!standalone) await createBlogDir(path);
+
+  await writeFile(filePath, frontMatter);
+  return filePath;
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { mkdir, writeFile } from 'fs/promises';
 import yaml from 'js-yaml';
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,28 +1,5 @@
-import { mkdir, writeFile } from 'fs/promises';
-import yaml from 'js-yaml';
-
-const createBlogDir = async (blogDir: string) => {
-  await mkdir(blogDir, { recursive: true });
-  return blogDir;
-};
-
-export interface CreateBlogOptions {
-  title: string;
-  author: string;
-  tags?: string[];
-  path: string;
-  standalone?: boolean;
-}
-
-export async function createBlogFile(opts: CreateBlogOptions) {
-  const { title, author: authors, tags, path, standalone = false } = opts;
-
-  const frontMatter = `---\n${yaml.dump({ title, authors, tags }, { flowLevel: 1 })}---\n\n<!--truncate-->\n`;
-
-  if (standalone) {
-    await writeFile(path + '.md', frontMatter);
-  } else {
-    await createBlogDir(path);
-    await writeFile(path + '/index.md', frontMatter);
-  }
-}
+export * from './authors';
+export * from './blogData';
+export * from './blogFile';
+export * from './questions';
+export * from './types';

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -1,59 +1,106 @@
-import prompts from 'prompts';
-import { AuthorChoices } from './authors';
-import { BlogData } from './blogData';
+import prompts, { PromptObject } from 'prompts';
+import { AuthorChoices, BlogData, CLIPromptOptions, PromptResponse } from './types';
 
-export function promptQuestions(authorChoices: AuthorChoices, fileData: BlogData) {
-  const { slugs, tags } = fileData;
-  return prompts(
-    [
-      {
-        type: 'select',
-        name: 'author',
-        message: 'Who is creating this blog?',
-        choices: authorChoices.map(([name]) => ({ title: name, value: name })),
+export async function promptQuestions(
+  authorChoices: AuthorChoices,
+  fileData: BlogData,
+  options: CLIPromptOptions
+): Promise<Omit<PromptResponse, 'newTags'>> {
+  const { slugs, tags: fileDataTags } = fileData;
+  const { author, date, promptNewTags, slug, standalone, tags, title } = options;
+  const questions: Array<PromptObject<keyof PromptResponse>> = [];
+  if (standalone === undefined) {
+    questions.push({
+      type: 'select',
+      name: 'standalone',
+      message: "Create a standalone file?\n(Yes if you're not including other files like images)",
+      choices: [
+        { title: 'yes', value: true },
+        { title: 'no', value: false },
+      ],
+      initial: false,
+    });
+  }
+
+  if (author === undefined) {
+    questions.push({
+      type: 'select',
+      name: 'author',
+      message: 'Who is creating this blog?',
+      choices: authorChoices.map(([name]) => ({ title: name, value: name })),
+    });
+  }
+
+  if (title === undefined) {
+    questions.push({
+      type: 'text',
+      name: 'title',
+      message: 'Title of the blog',
+      validate: (title) => (!title.length ? 'Please enter a title' : true),
+    });
+  }
+
+  if (slug === undefined) {
+    questions.push({
+      type: 'text',
+      name: 'slug',
+      message: 'URL slug for the blog',
+      validate: (slug) => (slugs.has(slug) ? `Slug \`${slug}\`already exists in blog` : true),
+      initial: (_, values) => {
+        const title = values.title || options.title;
+        return title
+          .split(' ')
+          .slice(0, 2)
+          .map((s: string) => s.toLowerCase())
+          .join('-');
       },
-      {
-        type: 'text',
-        name: 'title',
-        message: 'Title of the blog',
-        validate: (title) => (!title.length ? 'Please enter a title' : true),
-      },
-      {
-        type: 'text',
-        name: 'slug',
-        message: 'URL slug for the blog',
-        validate: (slug) => (slugs.has(slug) ? 'Slug already exists in blog' : true),
-        initial: (prev) =>
-          prev
-            .split(' ')
-            .slice(0, 2)
-            .map((s: string) => s.toLowerCase())
-            .join('-'),
-      },
-      {
-        type: 'autocompleteMultiselect',
-        name: 'tags',
-        message: 'Pick existing tags',
-        choices: Array.from(tags).map((t) => ({ title: t, value: t })),
-      },
-      {
-        type: 'list',
-        name: 'newTags',
-        format: (val) => val.map((v: string) => v.toString()),
-        message: 'List new tags (separated by commas)',
-      },
-      {
-        type: 'date',
-        name: 'date',
-        message: 'Date of blog',
-        mask: 'MMM DD YYYY',
-        initial: new Date(),
-      },
-    ],
-    {
-      onCancel: () => {
-        process.exit(0);
-      },
-    }
+    });
+  } else if (slugs.has(slug)) {
+    throw new Error(`Slug \`${slug}\` already exists in blog`);
+  }
+
+  if (tags === undefined) {
+    questions.push({
+      type: 'autocompleteMultiselect',
+      name: 'tags',
+      message: 'Pick existing tags',
+      choices: Array.from(fileDataTags).map((t) => ({ title: t, value: t })),
+    });
+  }
+
+  if (promptNewTags) {
+    questions.push({
+      type: 'list',
+      name: 'newTags',
+      format: (val) => val.map((v: string) => v.toString()),
+      message: 'List new tags (separated by commas)',
+    });
+  }
+
+  if (date === undefined) {
+    questions.push({
+      type: 'date',
+      name: 'date',
+      message: 'Date of blog',
+      mask: 'MMM DD YYYY',
+      initial: new Date(),
+    });
+  }
+
+  const givenOptions = { author, title, date, slug, standalone, tags };
+  const { newTags, tags: existingTags, ...rest } = await prompts(questions, { onCancel: () => process.exit(0) });
+  const combinedTags = Array.from(
+    new Set<string>(
+      (tags || existingTags)
+        .concat(newTags)
+        .filter((t: string) => !!t)
+        .map((t: string) => t.toLowerCase())
+    )
   );
+
+  return {
+    ...givenOptions,
+    tags: combinedTags,
+    ...rest,
+  };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,42 @@
+export type CLIPromptOptions = Partial<{
+  standalone: boolean;
+  author: string;
+  title: string;
+  slug: string;
+  tags: string;
+  promptNewTags: boolean;
+  date: Date;
+  mdx: boolean;
+}>;
+
+export interface PromptResponse {
+  standalone: boolean;
+  author: string;
+  title: string;
+  slug: string;
+  tags: string[];
+  newTags: string | string[];
+  date: Date;
+}
+
+export type BlogData = { slugs: Set<string>; tags: Set<string> };
+
+export type BlogAttributes = { slug: string; tags: string | string[] };
+
+export interface Author {
+  name: string;
+  title: string;
+  url: string;
+  image_url: string;
+}
+
+export type AuthorChoices = [string, Author][];
+
+export interface CreateBlogOptions {
+  title: string;
+  author: string;
+  tags?: string[];
+  path: string;
+  standalone?: boolean;
+  mdx?: boolean;
+}


### PR DESCRIPTION
BREAKING CHANGE:

To add new tags, pass the `--prompt-new-tags` option or `-p` flag

- Update README
- Pass options through command line to prevent prompting
- Option for MDX and standalone files

Closes #1.
Closes #2.
Closes #3.
Closes #4.
